### PR TITLE
Changed groupId to org.jmonkeyengine on the required modules

### DIFF
--- a/maven/lwjgl-platform.pom
+++ b/maven/lwjgl-platform.pom
@@ -1,11 +1,6 @@
 <project>
 	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.lwjgl.lwjgl</groupId>
-		<artifactId>parent</artifactId>
-		<version>@VERSION@</version>
-	</parent>
-	<groupId>org.lwjgl.lwjgl</groupId>
+	<groupId>org.jmonkeyengine</groupId>
 	<artifactId>lwjgl-platform</artifactId>
 	<packaging>pom</packaging>
 	<name>Lighweight Java Game Library - Platform</name>

--- a/maven/lwjgl.pom
+++ b/maven/lwjgl.pom
@@ -1,11 +1,6 @@
 <project>
 	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.lwjgl.lwjgl</groupId>
-		<artifactId>parent</artifactId>
-		<version>@VERSION@</version>
-	</parent>
-	<groupId>org.lwjgl.lwjgl</groupId>
+	<groupId>org.jmonkeyengine</groupId>
 	<artifactId>lwjgl</artifactId>
 	<packaging>jar</packaging>
 	<name>Lighweight Java Game Library</name>


### PR DESCRIPTION
Changed groupId to `org.jmonkeyengine` on the "lwjgl" and "lwjgl-platform" modules pom files that are needed to be published to the maven.